### PR TITLE
Convert details array to a Struct object

### DIFF
--- a/historic.rb
+++ b/historic.rb
@@ -97,8 +97,9 @@ file.readlines.each do |line|
 
   print "Job #{job.jobid} used #{gpus} GPUs, #{cpus}CPUs & #{mem.ceil(2)}MB on #{nodes}node(s) for #{time.ceil(2)}mins. "
 
-  instance_numbers = Instance.base_instance_numbers(cpus, gpus, mem)
-  best_fit_instances = Instance.best_fit_instances(instance_numbers, nodes)
+  instance_calculator = InstanceCalculator.new(cpus, gpus, mem, nodes)
+  instance_numbers = instance_calculator.base_instance_numbers(cpus, gpus, mem)
+  best_fit_instances = instance_calculator.best_fit_instances(instance_numbers, nodes)
   total_instances = instance_numbers.values.reduce(:+)
 
   cost_per_min = 0.0


### PR DESCRIPTION
This PR makes a change to the way that we read and access rows in the imported SLURM `sacct` output. Previously, each row was imported as an array and referenced via numeric indices. Now, a `Struct` object is created for each row, allowing for named attributes.

A couple of notes on these changes:
- Since the first row of the file is now being read prior to the `each` call, the first row 'header' check isn't necessary. For reasons unknown to man, `file.first` reads the line and _removes_ it from the `File`.
- I've used the `*` splat operator when creating new `Struct`s. This operator is essentially "given an array, pass each element of that array to the method as a separate argument". It means I don't have to type out all 56 array elements as arguments.