### PR TITLE
Require input file to be specific at command lne

### DIFF
--- a/historic.rb
+++ b/historic.rb
@@ -42,7 +42,12 @@ end
 
 user_args = Hash[ ARGV.join(' ').scan(/--?([^=\s]+)(?:=(\S+))?/) ]
 
-file = File.open(user_args['input'])
+begin
+  file = File.open(user_args['input'])
+rescue TypeError
+  puts 'Please specify an input file.'
+  exit 1
+end
 header = file.first.chomp
 cols = header.split('|')
 cols.map! { |col| col.downcase.to_sym }


### PR DESCRIPTION
This PR adds a command line argument parser to the application and makes the `--input` argument required. The `--input` argument specifies the input file containing the SLURM `sacct` output desired for the application. An error is handled when there is no input file specified.

Notes:
- The command line argument parser accepts arguments in the form `-arg`, `--arg`, or either of the prior plus a value (e.g. `--arg=choice`).
- In the code, a hash (`user_args`) is constructed, where each key is an argument name, and each value a value. If an argument is specified without a value, its value in the hash is `nil` (in this case, it should be considered a boolean trigger, and checked with `user_args.key?('arg')`).

Resolves #10  when merged.