### PR TITLE
Account for failed states in the report

### DIFF
--- a/historic.rb
+++ b/historic.rb
@@ -165,16 +165,6 @@ file.readlines.each do |line|
   end
 
   states[job.state] << { message: msg, time: time, mem: mem, best_fit_cost: best_fit_cost }
-end
-
-states.each do |state, jobs|
-  next if !jobs.any?
-  puts state
-  puts "#{'-'*50}\n"
-  puts jobs.map { |job| job[:message] }
-  puts
-
-
   if output
     CSV.open(output, "ab") do |csv|
       results = ["'#{job.jobid}", job.state, gpus, cpus, max_rss, mem.ceil(2), nodes, time,
@@ -186,6 +176,14 @@ states.each do |state, jobs|
       csv << results
     end
   end
+end
+
+states.each do |state, jobs|
+  next if !jobs.any?
+  puts state
+  puts "#{'-'*50}\n"
+  puts jobs.map { |job| job[:message] }
+  puts
 end
 
 puts "-" * 50

--- a/models/instance_calculator.rb
+++ b/models/instance_calculator.rb
@@ -33,7 +33,7 @@ class InstanceCalculator
   end
 
   def best_fit_type
-    @best_fit_instance.type
+    @best_fit_instance.name
   end
 
   def best_fit_description
@@ -51,7 +51,7 @@ class InstanceCalculator
   def any_nodes_type
     return if !@any_nodes_instance
 
-    @any_nodes_instance.type
+    @any_nodes_instance.name
   end
 
   def any_nodes_description


### PR DESCRIPTION
This PR adds a new command line flag (`--include-failed`) to the application that includes jobs with [states](https://github.com/openflighthpc/cloud-job-cost-estimator/issues/3#issuecomment-716618938) other than `COMPLETED` in the reporting process. The states that are permitted are set in an array constant at the start of the program.

Also, the output has been changed to group jobs by their state. Note that for the standard output, there will be one single group (`COMPLETED`).