### PR TITLE
Fix/improve cost differences

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Job 002 used 0 GPUs, 4CPUs & 8.81MB on 1 node(s) for 12mins. Instance config of 
 With this argument included, instance configurations will also be suggested with any number of nodes (regardless of how many the job actually used), if this result is different from the original suggestion. This includes the associated cost and how this differs (if at all):
 
 ```
-Job 005 used 0 GPUs, 40CPUs & 8.81MB on 1 node(s) for 12mins. To meet requirements, larger instance(s) required than base equivalent. Instance config of 1 c5.12xlarge would cost $0.49. Ignoring node counts, best fit would be 5 c5.2xlarge at a cost of $0.41 (-$0.081).
+Job 005 used 0 GPUs, 40CPUs & 8.81MB on 1 node(s) for 12mins. To meet requirements, larger instance(s) required than base equivalent. Instance config of 1 c5.12xlarge would cost $0.49. Ignoring node counts, best fit would be 5 c5.2xlarge at a cost of $0.41 (saving $0.081).
 Job 006 used 8 GPUs, 36CPUs & 908.6MB on 2 node(s) for 18mins. Instance config of 2 p3.8xlarge would cost $8.62. Ignoring node counts, best fit would be 1 p3.16xlarge at a cost of $8.62 (same cost).
 ```
 

--- a/analyse_jobs.rb
+++ b/analyse_jobs.rb
@@ -133,7 +133,7 @@ if output
 
   csv_headers = %w[job_id state gpus cpus base_max_rss_mb adjusted_max_rss_mb num_nodes 
                    elapsed_mins suggested_num suggested_type suggested_cost_usd]
-  csv_headers.concat(%w[any_nodes_num any_nodes_type any_nodes_cost_usd cost_diff_usd]) if include_any_node_numbers
+  csv_headers.concat(%w[any_nodes_num any_nodes_type any_nodes_cost_usd cost_saving_usd]) if include_any_node_numbers
   CSV.open(output, "wb") do |csv|
     csv << csv_headers
   end
@@ -214,7 +214,7 @@ file.readlines.each do |line|
       any_nodes_cost_diff = instance_calculator.any_nodes_best_fit_cost_diff
       msg << " Ignoring node counts, best fit would be #{instance_calculator.any_nodes_description}"
       msg << " at a cost of $#{any_nodes_cost.to_f.ceil(2)}"
-      msg << (any_nodes_cost_diff == 0 ? " (same cost)" : " (-$#{any_nodes_cost_diff.to_f.ceil(3)})")
+      msg << (any_nodes_cost_diff == 0 ? " (same cost)" : " (saving $#{any_nodes_cost_diff.to_f.ceil(3)})")
       msg << "."
     end
   end

--- a/models/instance_calculator.rb
+++ b/models/instance_calculator.rb
@@ -198,7 +198,7 @@ class InstanceCalculator
   def any_nodes_best_fit_cost_diff
     return if !@any_nodes_instance
 
-    total_any_nodes_cost - total_best_fit_cost
+    total_best_fit_cost - total_any_nodes_cost
   end
 
   private


### PR DESCRIPTION
Aims to resolve #31 and make the meaning of the displayed cost differences clearer

- Makes cost differences positive and replaces negative sign with the word 'saving'

E.g. `Ignoring node counts, best fit would be 1 c5.xlarge at a cost of $16.0 (saving $7.996).`